### PR TITLE
prompt und system message angepasst

### DIFF
--- a/public/crawl.php
+++ b/public/crawl.php
@@ -76,17 +76,8 @@ foreach($crawlListURLs as $crawlListURL ){
                  json_encode($examplesArray, JSON_PRETTY_PRINT) . "\n" .
                  '</example>';
                  
-          /*  $response =  $this->makeRequest($client, [
-                'messages' => [
-                    ['role' => 'system', 'content' =>  $basicEventInfoMessage],
-                    ['role' => 'user', 'content' => $message],
-                ],
-                'response_format' => [
-                    'type' => 'json_object',
-                ],
-            ]);*/
- //echo $basicEventInfoMessage; die;
-  $answers = $client->chat(  $markdown , $model, $basicEventInfoMessage);
+
+  $answers = $client->chat(  $markdown . "\n" . $basicEventInfoMessage , $model, 'You are a helpful assistant.');
   $offer = null;
   foreach ($answers as $answer) {
     verbose( '<br><strong>Ergebnis</strong><hr>'.nl2br($answer) . '<hr>');


### PR DESCRIPTION
Bei der Abfrage an die KI haben wir bisher das Markup der Webseite in den Prompt geladen und den fragenden Prompt als System-Prompt übergeben. Terences manuellen Tests haben aber herausgefunden, dass das Ergebnis besser ist, wenn die Frage an die KI direkt nach dem Markup der Webseite übergeben wird und nur ein Standard Systemprompt (you are a hepful assistant) übergeben wird. Genau das wird mit diesem PR umgesetzt. 